### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ record the string's size and encoding.
 require 'lz4_flex'
 
 # Compress data
-compressed = LZ4Flex.compress("Hello, World!")
+compressed = Lz4Flex.compress("Hello, World!")
 
 # Decompress data
-decompressed = LZ4Flex.decompress(compressed)
+decompressed = Lz4Flex.decompress(compressed)
 
 puts decompressed  # => "Hello, World!"
 puts decompressed.encoding # => Encoding::UTF_8


### PR DESCRIPTION
I was running a quick benchmark and noticed the readme had a formatting/typo issue. Nice to have it easy to copy and test from the readme, so a tiny PR.

I noticed you have a benchmark it might be nice to check in the output with some info on what it was run on... I just put one together quickly before seeing it.

My bench did put this on top of the other compression algos, not by a lot but still a simple win:

```
cache with compression
                        146.695 (±81.1%) i/s -    264.000 in  23.939195s
adding report
cache with snappy compression
                        126.183 (±66.6%) i/s -    156.000 in  12.948649s
adding report
cache with l4z compression
                        171.370 (±51.4%) i/s -    357.000 in  15.027031s
adding report
cache with l4z_flex compression
                        204.913 (±50.3%) i/s -    103.000 in  11.849561s
adding report

Comparison:
cache with l4z_flex compression:      204.9 i/s
cache with l4z compression:      171.4 i/s - same-ish: difference falls within error
cache with compression:      146.7 i/s - same-ish: difference falls within error
cache with snappy compression:      126.2 i/s - same-ish: difference falls within error
```