### PR TITLE
Fix extension loading for ruby head

### DIFF
--- a/lib/lz4_flex.rb
+++ b/lib/lz4_flex.rb
@@ -6,5 +6,5 @@ begin
   RUBY_VERSION =~ /(\d+\.\d+)/
   require "lz4_flex/#{Regexp.last_match(1)}/lz4_flex_ext"
 rescue LoadError
-  require_relative "lz4_flex/lz4_flex_ext"
+  require "lz4_flex/lz4_flex_ext"
 end


### PR DESCRIPTION
The object is no longer copied into the lib dir as of https://github.com/ruby/rubygems/commit/1614b036f7
